### PR TITLE
Unset request ID at end of process_response

### DIFF
--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -38,6 +38,8 @@ class RequestIDMiddleware(object):
             args += (user_id,)
 
         logger.info(message, *args)
+        
+        del local.request_id
 
         return response
 

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -15,10 +15,10 @@ ROOT_URLCONF = "testproject.urls"
 
 INSTALLED_APPS = ["log_request_id"]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'log_request_id.middleware.RequestIDMiddleware',
     # ... other middleware goes here
-) + global_settings.MIDDLEWARE_CLASSES
+] + list(global_settings.MIDDLEWARE_CLASSES)
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
This will prevent the request ID from bleeding into any logging that might happen on the next request.