### PR TITLE
Fix #13 -- Catch AttributeError if unset

### DIFF
--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -39,7 +39,10 @@ class RequestIDMiddleware(object):
 
         logger.info(message, *args)
         
-        del local.request_id
+        try:
+            del local.request_id
+        except AttributeError:
+            pass
 
         return response
 


### PR DESCRIPTION
If you use a Django route without the trailing slash, `django.middlware.common.CommonMiddleware` will redirect to the proper URL.
In this scenario the request ist never processed by the `RequestIDMiddleware`, therefore will there be no request_id in the thread local.