### PR TITLE
Make middleware compatible with django 1.10 MIDDLEWARE setting

### DIFF
--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -2,6 +2,10 @@ import logging
 import uuid
 
 from django.conf import settings
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTING, NO_REQUEST_ID, \
     REQUEST_ID_RESPONSE_HEADER_SETTING, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING
 
@@ -9,7 +13,7 @@ from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTIN
 logger = logging.getLogger(__name__)
 
 
-class RequestIDMiddleware(object):
+class RequestIDMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         request_id = self._get_request_id(request)


### PR DESCRIPTION
I think your tests currently pass django 1.10 because the test project is still using the MIDDLEWARE_CLASSES setting, which apparently preserves the old behavior. This project is not usable on projects that migrate to the MIDDLEWARE setting used in Django 1.10. On those, it fails with:

```python
Traceback (most recent call last):
  File "/venv/lib/python2.7/site-packages/django/utils/autoreload.py", line 226, in wrapper
    fn(*args, **kwargs)
  File "/venv/lib/python2.7/site-packages/django/core/management/commands/runserver.py", line 142, in inner_run
    handler = self.get_handler(*args, **options)
  File "/venv/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/runserver.py", line 27, in get_handler
    handler = super(Command, self).get_handler(*args, **options)
  File "/venv/lib/python2.7/site-packages/django/core/management/commands/runserver.py", line 64, in get_handler
    return get_internal_wsgi_application()
  File "/venv/lib/python2.7/site-packages/django/core/servers/basehttp.py", line 49, in get_internal_wsgi_application
    return import_string(app_path)
  File "/venv/lib/python2.7/site-packages/django/utils/module_loading.py", line 20, in import_string
    module = import_module(module_path)
  File "/usr/local/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/myproject/wsgi.py", line 15, in <module>
    application = get_wsgi_application()
  File "/venv/lib/python2.7/site-packages/django/core/wsgi.py", line 14, in get_wsgi_application
    return WSGIHandler()
  File "/venv/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 153, in __init__
    self.load_middleware()
  File "/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 82, in load_middleware
    mw_instance = middleware(handler)
TypeError: object() takes no parameters
```