### PR TITLE
Tweak to make `request_id` attribute configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ LOGGING = {
     'filters': {
         'request_id': {
             '()': 'log_request_id.filters.RequestIDFilter'
+            # Optionally change the default `request_id` attribute
+            # 'request_id_attr': 'REQUEST_UID',
         }
     },
     'formatters': {

--- a/log_request_id/filters.py
+++ b/log_request_id/filters.py
@@ -4,6 +4,11 @@ from log_request_id import local, NO_REQUEST_ID
 
 class RequestIDFilter(logging.Filter):
 
+    def __init__(self, name='', request_id_attr='request_id'):
+        self.request_id_attr = request_id_attr
+        super(RequestIDFilter, self).__init__(name)
+
     def filter(self, record):
-        record.request_id = getattr(local, 'request_id', NO_REQUEST_ID)
+        setattr(record, self.request_id_attr,
+                getattr(local, 'request_id', NO_REQUEST_ID))
         return True


### PR DESCRIPTION
The use case I have for this is logging to Systemd's Journal. The
logging handler they provide can pass extra record attributes as
KEY=value to the journal, but only if the key is uppercase. See
https://www.freedesktop.org/software/systemd/python-systemd/journal.html#journalhandler-class