### PR TITLE
Add Test Support for Python 3.6 and Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
  - TOXENV=py27-django18
  - TOXENV=py27-django19
  - TOXENV=py27-django110
- - TOXENV=py35-django18
- - TOXENV=py35-django19
- - TOXENV=py35-django110
+ - TOXENV=py27-django111
+ - TOXENV=py36-django18
+ - TOXENV=py36-django19
+ - TOXENV=py36-django110
+ - TOXENV=py36-django111

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
 install:
  - pip install tox
  - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
 install:
  - pip install tox

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -1,7 +1,7 @@
 import django
 from testproject import views
 
-if django.VERSION[1] < 9:
+if django.VERSION < (1, 9):
     from django.conf.urls import patterns, url
     urlpatterns = patterns(
         '',

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -1,8 +1,15 @@
-from django.conf.urls import patterns, url
+import django
 from testproject import views
 
+if django.VERSION[1] < 9:
+    from django.conf.urls import patterns, url
+    urlpatterns = patterns(
+        '',
+        url(r'^$', views.test_view),
+    )
 
-urlpatterns = patterns(
-    '',
-    url(r'^$', views.test_view),
-)
+else:
+    from django.conf.urls import url
+    urlpatterns = [
+        url(r'^$', views.test_view),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
         django18: Django==1.8.14
         django19: Django==1.9.9
         django110: Django==1.10
-	django111: Django==1.11
+        django111: Django==1.11
         -rrequirements.txt
 commands = django-admin.py test
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-django14,
-    {py27,py34,py35}-{django18,django19,django110}
+    {py27,py34,py35,py36}-{django18,django19,django110,django111}
 
 [testenv]
 deps =
@@ -9,6 +9,7 @@ deps =
         django18: Django==1.8.14
         django19: Django==1.9.9
         django110: Django==1.10
+	django111: Django==1.11
         -rrequirements.txt
 commands = django-admin.py test
 setenv =


### PR DESCRIPTION
# Purpose

I'd like to use this library for a python 3.6 and Django 1.11 project.

Relates to issue https://github.com/dabapps/django-log-request-id/issues/26

# Details

- Add python36 to python test versions
- Add django 1.11 to django test versions
- Add django version check in URLs to account for deprecated `django.conf.urls.patterns` tool
  - Deprecated since 1.8
  - Removed in 1.11
  - https://docs.djangoproject.com/en/1.9/ref/urls/#patterns