### PR TITLE
Adds the ability to change the default value of missing request_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ If you wish to include the request id in the response headers, add the following
 REQUEST_ID_RESPONSE_HEADER = "RESPONSE_HEADER_NAME"
 ```
 
+If you wish to change the default `request_id` in the log output, the the following settings, where `none` (default) is the value you want to be the default value in case it's missing.
+
+```python
+NO_REQUEST_ID = "none"
+```
+
 Logging all requests
 --------------------
 

--- a/log_request_id/__init__.py
+++ b/log_request_id/__init__.py
@@ -1,7 +1,6 @@
 import threading
 
-
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 
 local = threading.local()
@@ -9,7 +8,8 @@ local = threading.local()
 
 REQUEST_ID_HEADER_SETTING = 'LOG_REQUEST_ID_HEADER'
 LOG_REQUESTS_SETTING = 'LOG_REQUESTS'
-NO_REQUEST_ID = "none"  # Used if no request ID is available
+LOG_REQUESTS_NO_SETTING = 'NO_REQUEST_ID'
+DEFAULT_NO_REQUEST_ID = "none"  # Used if no request ID is available
 REQUEST_ID_RESPONSE_HEADER_SETTING = 'REQUEST_ID_RESPONSE_HEADER'
 OUTGOING_REQUEST_ID_HEADER_SETTING = 'OUTGOING_REQUEST_ID_HEADER'
 GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING = 'GENERATE_REQUEST_ID_IF_NOT_IN_HEADER'

--- a/log_request_id/filters.py
+++ b/log_request_id/filters.py
@@ -1,9 +1,13 @@
 import logging
-from log_request_id import local, NO_REQUEST_ID
+
+from django.conf import settings
+
+from log_request_id import DEFAULT_NO_REQUEST_ID, LOG_REQUESTS_NO_SETTING, local
 
 
 class RequestIDFilter(logging.Filter):
 
     def filter(self, record):
-        record.request_id = getattr(local, 'request_id', NO_REQUEST_ID)
+        default_request_id = getattr(settings, LOG_REQUESTS_NO_SETTING, DEFAULT_NO_REQUEST_ID)
+        record.request_id = getattr(local, 'request_id', default_request_id)
         return True

--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -6,8 +6,8 @@ try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
     MiddlewareMixin = object
-from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTING, NO_REQUEST_ID, \
-    REQUEST_ID_RESPONSE_HEADER_SETTING, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING
+from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTING, DEFAULT_NO_REQUEST_ID, \
+    REQUEST_ID_RESPONSE_HEADER_SETTING, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING, LOG_REQUESTS_NO_SETTING
 
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class RequestIDMiddleware(MiddlewareMixin):
         if request_id_header:
             # fallback to NO_REQUEST_ID if settings asked to use the
             # header request_id but none provided
-            default_request_id = NO_REQUEST_ID
+            default_request_id = getattr(settings, LOG_REQUESTS_NO_SETTING, DEFAULT_NO_REQUEST_ID)
 
             # unless the setting GENERATE_REQUEST_ID_IF_NOT_IN_HEADER
             # was set, in which case generate an id as normal if it wasn't

--- a/log_request_id/session.py
+++ b/log_request_id/session.py
@@ -2,8 +2,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from requests import Session as BaseSession
 
-from log_request_id import DEFAULT_NO_REQUEST_ID, LOG_REQUESTS_NO_SETTING, OUTGOING_REQUEST_ID_HEADER_SETTING, \
-    REQUEST_ID_HEADER_SETTING, local
+from log_request_id import DEFAULT_NO_REQUEST_ID, OUTGOING_REQUEST_ID_HEADER_SETTING, REQUEST_ID_HEADER_SETTING, local
 
 
 class Session(BaseSession):
@@ -24,10 +23,9 @@ class Session(BaseSession):
         """Include the request ID, if available, in the outgoing request"""
         try:
             request_id = local.request_id
+            if self.request_id_header:
+                request.headers[self.request_id_header] = request_id
         except AttributeError:
-            request_id = getattr(settings, LOG_REQUESTS_NO_SETTING, DEFAULT_NO_REQUEST_ID)
-
-        if self.request_id_header and request_id != DEFAULT_NO_REQUEST_ID:
-            request.headers[self.request_id_header] = request_id
+            pass
 
         return super(Session, self).prepare_request(request)

--- a/log_request_id/session.py
+++ b/log_request_id/session.py
@@ -1,8 +1,8 @@
-from requests import Session as BaseSession
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from requests import Session as BaseSession
 
-from log_request_id import local, REQUEST_ID_HEADER_SETTING, NO_REQUEST_ID, OUTGOING_REQUEST_ID_HEADER_SETTING
+from log_request_id import DEFAULT_NO_REQUEST_ID, OUTGOING_REQUEST_ID_HEADER_SETTING, REQUEST_ID_HEADER_SETTING, local
 
 
 class Session(BaseSession):
@@ -24,9 +24,9 @@ class Session(BaseSession):
         try:
             request_id = local.request_id
         except AttributeError:
-            request_id = NO_REQUEST_ID
+            request_id = DEFAULT_NO_REQUEST_ID
 
-        if self.request_id_header and request_id != NO_REQUEST_ID:
+        if self.request_id_header and request_id != DEFAULT_NO_REQUEST_ID:
             request.headers[self.request_id_header] = request_id
 
         return super(Session, self).prepare_request(request)

--- a/log_request_id/session.py
+++ b/log_request_id/session.py
@@ -2,7 +2,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from requests import Session as BaseSession
 
-from log_request_id import DEFAULT_NO_REQUEST_ID, OUTGOING_REQUEST_ID_HEADER_SETTING, REQUEST_ID_HEADER_SETTING, local
+from log_request_id import DEFAULT_NO_REQUEST_ID, LOG_REQUESTS_NO_SETTING, OUTGOING_REQUEST_ID_HEADER_SETTING, \
+    REQUEST_ID_HEADER_SETTING, local
 
 
 class Session(BaseSession):
@@ -24,7 +25,7 @@ class Session(BaseSession):
         try:
             request_id = local.request_id
         except AttributeError:
-            request_id = DEFAULT_NO_REQUEST_ID
+            request_id = getattr(settings, LOG_REQUESTS_NO_SETTING, DEFAULT_NO_REQUEST_ID)
 
         if self.request_id_header and request_id != DEFAULT_NO_REQUEST_ID:
             request.headers[self.request_id_header] = request_id

--- a/log_request_id/tests.py
+++ b/log_request_id/tests.py
@@ -1,8 +1,10 @@
 import logging
-from django.test import TestCase, RequestFactory
+
 from django.core.exceptions import ImproperlyConfigured
+from django.test import RequestFactory, TestCase, override_settings
 from requests import Request
 
+from log_request_id import DEFAULT_NO_REQUEST_ID, local
 from log_request_id.middleware import RequestIDMiddleware
 from testproject.views import test_view
 
@@ -13,6 +15,12 @@ class RequestIDLoggingTestCase(TestCase):
         self.factory = RequestFactory()
         self.handler = logging.getLogger('testproject').handlers[0]
         self.handler.messages = []
+
+        # Ensure that there is nothing lurking around from previous tests
+        try:
+            del local.request_id
+        except AttributeError:
+            pass
 
     def test_id_generation(self):
         request = self.factory.get('/')
@@ -31,6 +39,17 @@ class RequestIDLoggingTestCase(TestCase):
             self.assertEqual(request.id, 'some_request_id')
             test_view(request)
             self.assertTrue('some_request_id' in self.handler.messages[0])
+
+    def test_default_no_request_id_is_used(self):
+        request = self.factory.get('/')
+        test_view(request)
+        self.assertTrue(DEFAULT_NO_REQUEST_ID in self.handler.messages[0])
+
+    @override_settings(NO_REQUEST_ID='-')
+    def test_custom_request_id_is_used(self):
+        request = self.factory.get('/')
+        test_view(request)
+        self.assertTrue('[-]' in self.handler.messages[0])
 
     def test_external_id_missing_in_http_header_should_fallback_to_generated_id(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER', GENERATE_REQUEST_ID_IF_NOT_IN_HEADER=True):

--- a/log_request_id/tests.py
+++ b/log_request_id/tests.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from requests import Request
 
 from log_request_id import DEFAULT_NO_REQUEST_ID, local
+from log_request_id.session import Session
 from log_request_id.middleware import RequestIDMiddleware
 from testproject.views import test_view
 
@@ -101,7 +102,6 @@ class RequestIDPassthroughTestCase(TestCase):
 
     def test_request_id_passthrough_with_custom_header(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER', OUTGOING_REQUEST_ID_HEADER='OUTGOING_REQUEST_ID_HEADER'):
-            from log_request_id.session import Session
             request = self.factory.get('/')
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             middleware = RequestIDMiddleware()
@@ -117,7 +117,6 @@ class RequestIDPassthroughTestCase(TestCase):
 
     def test_request_id_passthrough(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER'):
-            from log_request_id.session import Session
             request = self.factory.get('/')
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             middleware = RequestIDMiddleware()
@@ -133,6 +132,5 @@ class RequestIDPassthroughTestCase(TestCase):
 
     def test_misconfigured_for_sessions(self):
         def inner():
-            from log_request_id.session import Session  # noqa
             Session()
         self.assertRaises(ImproperlyConfigured, inner)


### PR DESCRIPTION
We have a lot of logs, including in celery workers. These workers as you can imagine won't ever have a `request_id`, in order to keep all our logs looking the same we normally put `-` as the missing value of our filters, nginx i think does the same, either way most of our filters default to that and yours is the only one that has `none` on it.