### PR TITLE
Add documentation to access ID in views

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ session.get('http://myservice.myapp.com/')
 You can customise the header used in the outgoing request with the `OUTGOING_REQUEST_ID_HEADER` setting.
 
 
+Usage in views
+--------------
+
+To access the ID in views, use `request.id`. An example of this would be:
+
+    def test_view(request):
+        print(request.id)
+        return HttpResponse(f"The request ID is: {request.id}")
+
 License
 -------
 


### PR DESCRIPTION
Why:

- Allow the use of the ID in business logic

This change addresses the need by:

- Adding a subheading in the readme
- Extending the example project with access to the request ID