### PR TITLE
Add support for async views

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
-        django: [1.8, 1.11, 2.2, 3.1]
+        python: [3.6, 3.7, 3.8, 3.9]
+        django: [2.2, 3.0, 3.1, 3.2rc1]
 
     steps:
     - uses: actions/checkout@v2

--- a/log_request_id/__init__.py
+++ b/log_request_id/__init__.py
@@ -3,7 +3,13 @@ import threading
 __version__ = "1.6.0"
 
 
-local = threading.local()
+try:
+    from asgiref.local import Local
+except ImportError:
+    from threading import local as Local
+
+
+local = Local()
 
 
 REQUEST_ID_HEADER_SETTING = 'LOG_REQUEST_ID_HEADER'

--- a/log_request_id/tests.py
+++ b/log_request_id/tests.py
@@ -1,5 +1,10 @@
 import logging
 
+try:
+    from asgiref.sync import async_to_sync
+except ImportError:
+    async_to_sync = None
+
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
 from requests import Request
@@ -7,10 +12,14 @@ from requests import Request
 from log_request_id import DEFAULT_NO_REQUEST_ID, local
 from log_request_id.session import Session
 from log_request_id.middleware import RequestIDMiddleware
-from testproject.views import test_view
+from testproject.views import test_view, test_async_view
 
 
 class RequestIDLoggingTestCase(TestCase):
+    url = "/"
+
+    def call_view(self, request):
+        return test_view(request)
 
     def setUp(self):
         self.factory = RequestFactory()
@@ -24,41 +33,41 @@ class RequestIDLoggingTestCase(TestCase):
             pass
 
     def test_id_generation(self):
-        request = self.factory.get('/')
+        request = self.factory.get(self.url)
         middleware = RequestIDMiddleware()
         middleware.process_request(request)
         self.assertTrue(hasattr(request, 'id'))
-        test_view(request)
+        self.call_view(request)
         self.assertTrue(request.id in self.handler.messages[0])
 
     def test_external_id_in_http_header(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER'):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
             self.assertEqual(request.id, 'some_request_id')
-            test_view(request)
+            self.call_view(request)
             self.assertTrue('some_request_id' in self.handler.messages[0])
 
     def test_default_no_request_id_is_used(self):
-        request = self.factory.get('/')
-        test_view(request)
+        request = self.factory.get(self.url)
+        self.call_view(request)
         self.assertTrue(DEFAULT_NO_REQUEST_ID in self.handler.messages[0])
 
     @override_settings(NO_REQUEST_ID='-')
     def test_custom_request_id_is_used(self):
-        request = self.factory.get('/')
-        test_view(request)
+        request = self.factory.get(self.url)
+        self.call_view(request)
         self.assertTrue('[-]' in self.handler.messages[0])
 
     def test_external_id_missing_in_http_header_should_fallback_to_generated_id(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER', GENERATE_REQUEST_ID_IF_NOT_IN_HEADER=True):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
             self.assertTrue(hasattr(request, 'id'))
-            test_view(request)
+            self.call_view(request)
             self.assertTrue(request.id in self.handler.messages[0])
 
     def test_log_requests(self):
@@ -67,11 +76,11 @@ class RequestIDLoggingTestCase(TestCase):
             pk = 'fake_pk'
 
         with self.settings(LOG_REQUESTS=True):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             request.user = DummyUser()
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
-            response = test_view(request)
+            response = self.call_view(request)
             middleware.process_response(request, response)
             self.assertEqual(len(self.handler.messages), 2)
             self.assertTrue('fake_pk' in self.handler.messages[1])
@@ -83,42 +92,44 @@ class RequestIDLoggingTestCase(TestCase):
             username = 'fake_username'
 
         with self.settings(LOG_REQUESTS=True, LOG_USER_ATTRIBUTE='username'):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             request.user = DummyUser()
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
-            response = test_view(request)
+            response = self.call_view(request)
             middleware.process_response(request, response)
             self.assertEqual(len(self.handler.messages), 2)
             self.assertTrue('fake_username' in self.handler.messages[1])
 
     def test_response_header_unset(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER'):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
-            response = test_view(request)
+            response = self.call_view(request)
             self.assertFalse(response.has_header('REQUEST_ID'))
 
     def test_response_header_set(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER', REQUEST_ID_RESPONSE_HEADER='REQUEST_ID'):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
-            response = test_view(request)
+            response = self.call_view(request)
             middleware.process_response(request, response)
             self.assertTrue(response.has_header('REQUEST_ID'))
 
 
 class RequestIDPassthroughTestCase(TestCase):
+    url = "/"
+
     def setUp(self):
         self.factory = RequestFactory()
 
     def test_request_id_passthrough_with_custom_header(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER', OUTGOING_REQUEST_ID_HEADER='OUTGOING_REQUEST_ID_HEADER'):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
@@ -133,7 +144,7 @@ class RequestIDPassthroughTestCase(TestCase):
 
     def test_request_id_passthrough(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER'):
-            request = self.factory.get('/')
+            request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             middleware = RequestIDMiddleware()
             middleware.process_request(request)
@@ -150,3 +161,16 @@ class RequestIDPassthroughTestCase(TestCase):
         def inner():
             Session()
         self.assertRaises(ImproperlyConfigured, inner)
+
+
+if async_to_sync:
+
+    class AsyncRequestIDLoggingTestCase(RequestIDLoggingTestCase):
+        url = "/async/"
+
+        def call_view(self, request):
+            return async_to_sync(test_async_view)(request)
+
+
+    class AsyncRequestIDPassthroughTestCase(RequestIDPassthroughTestCase):
+        url = "/async/"

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -1,15 +1,8 @@
-import django
+from django.urls import path
 from testproject import views
 
-if django.VERSION < (1, 9):
-    from django.conf.urls import patterns, url
-    urlpatterns = patterns(
-        '',
-        url(r'^$', views.test_view),
-    )
 
-else:
-    from django.conf.urls import url
-    urlpatterns = [
-        url(r'^$', views.test_view),
-    ]
+urlpatterns = [
+    path("", views.test_view),
+    path("async/", views.test_async_view),
+]

--- a/testproject/views.py
+++ b/testproject/views.py
@@ -8,3 +8,8 @@ logger = logging.getLogger(__name__)
 def test_view(request):
     logger.debug("A wild log message appears!")
     return HttpResponse('ok')
+
+
+async def test_async_view(request):
+    logger.debug("An async log message appears")
+    return HttpResponse('ok')


### PR DESCRIPTION
This uses `asgiref.local` instead of `threading.local` where available. Roughly based on [this](https://github.com/jazzband/django-simple-history/pull/749).

I've also dropped support for older Django version and added in Python 3.9 and Django 3.2rc1. We should wait till 3.2 comes out before releasing this probably.