### PR TITLE
Fix #64 -- ability to not log user attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The `RequestIDMiddleware` also has the ability to log all requests received by t
 Logging other user attributes
 --------------------
 
-If you would like to log another user attribute instead of user ID, this can be specified with the `LOG_USER_ATTRIBUTE` setting. Eg. to log the username, use: `LOG_USER_ATTRIBUTE = "username"`
+If you would like to log another user attribute instead of user ID, this can be specified with the `LOG_USER_ATTRIBUTE` setting. Eg. to log the username, use: `LOG_USER_ATTRIBUTE = "username"`. If this setting is set to `None`, no user attribute will be logged.
 
 License
 -------

--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -23,20 +23,22 @@ class RequestIDMiddleware(MiddlewareMixin):
     def get_log_message(self, request, response):
         message = 'method=%s path=%s status=%s' % (request.method, request.path, response.status_code)
 
+        # `LOG_USER_ATTRIBUTE_SETTING` accepts False/None to skip setting attribute
+        #  but falls back to 'pk' if value is not set
+        user_attribute = getattr(settings, LOG_USER_ATTRIBUTE_SETTING, 'pk')
+        if not user_attribute:
+            return message
+
+        # avoid accessing session if it is empty
         if getattr(request, 'session', None) and request.session.is_empty():
-            # avoid accessing session if it is empty
             return message
 
         user = getattr(request, 'user', None)
         if not user:
             return message
 
-        # `LOG_USER_ATTRIBUTE_SETTING` accepts False/None to skip setting attribute
-        #  but falls back to 'pk' if value is not set
-        user_attribute = getattr(settings, LOG_USER_ATTRIBUTE_SETTING, 'pk')
-        if user_attribute:
-            user_id = getattr(user, user_attribute, None) or getattr(user, 'id', None)
-            message += ' user=' + str(user_id)
+        user_id = getattr(user, user_attribute, None) or getattr(user, 'id', None)
+        message += ' user=' + str(user_id)
         return message
 
     def process_response(self, request, response):

--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -23,9 +23,12 @@ class RequestIDMiddleware(MiddlewareMixin):
     def get_log_message(self, request, response):
         message = 'method=%s path=%s status=%s' % (request.method, request.path, response.status_code)
 
+        if getattr(request, 'session', None) and request.session.is_empty():
+            # avoid accessing session if it is empty
+            return message
+
         user = getattr(request, 'user', None)
-        # avoid accessing session if it is empty
-        if (getattr(request, 'session', None) and request.session.is_empty()) or not user:
+        if not user:
             return message
 
         # `LOG_USER_ATTRIBUTE_SETTING` accepts False/None to skip setting attribute


### PR DESCRIPTION
Also, this PR adds session check to not trigger patching response headers with Vary: Cookie in case of empty session. See #64 for details.
