### PR TITLE
Update middleware to be compatible with Django 4.0

### DIFF
--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 
 from django.conf import settings
+from django.http import HttpResponse
+
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
@@ -15,6 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 class RequestIDMiddleware(MiddlewareMixin):
+    def __init__(self, get_response=None):
+        if get_response is None:
+            get_response = HttpResponse()
+
+        super().__init__(get_response)
+
     def process_request(self, request):
         request_id = self._get_request_id(request)
         local.request_id = request_id


### PR DESCRIPTION
The get_response argument for django.utils.deprecation.MiddlewareMixin.__init__() is required and doesn’t accept None

[Reference Link](https://docs.djangoproject.com/en/4.1/releases/4.0/#features-removed-in-4-0)