### PR TITLE
Refactor settings in middleware to be loaded once rather than per request

### DIFF
--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -30,7 +30,9 @@ class RequestIDMiddleware:
         # unless the setting GENERATE_REQUEST_ID_IF_NOT_IN_HEADER
         # was set, in which case generate an id as normal if it wasn't
         # passed in via the header
-        self.generate_request_if_not_in_header = getattr(settings, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING, False)
+        self.generate_request_id_if_not_in_header = getattr(
+            settings, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING, False
+        )
 
     def __call__(self, request):
         local.request_id = request.id = request_id = self._get_request_id(request)
@@ -71,7 +73,7 @@ class RequestIDMiddleware:
         if self.request_id_header:
             default_request_id = self.default_request_id
 
-            if self.generate_request_if_not_in_header:
+            if self.generate_request_id_if_not_in_header:
                 default_request_id = self._generate_id()
 
             return request.META.get(self.request_id_header, default_request_id)

--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -2,10 +2,7 @@ import logging
 import uuid
 
 from django.conf import settings
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = object
+
 from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTING, DEFAULT_NO_REQUEST_ID, \
     REQUEST_ID_RESPONSE_HEADER_SETTING, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING, LOG_REQUESTS_NO_SETTING, \
     LOG_USER_ATTRIBUTE_SETTING
@@ -14,45 +11,37 @@ from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTIN
 logger = logging.getLogger(__name__)
 
 
-class RequestIDMiddleware(MiddlewareMixin):
-    def process_request(self, request):
-        request_id = self._get_request_id(request)
-        local.request_id = request_id
-        request.id = request_id
-
-    def get_log_message(self, request, response):
-        message = 'method=%s path=%s status=%s' % (request.method, request.path, response.status_code)
+class RequestIDMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
 
         # `LOG_USER_ATTRIBUTE_SETTING` accepts False/None to skip setting attribute
         #  but falls back to 'pk' if value is not set
-        user_attribute = getattr(settings, LOG_USER_ATTRIBUTE_SETTING, 'pk')
-        if not user_attribute:
-            return message
+        self.log_user_attribute = getattr(settings, LOG_USER_ATTRIBUTE_SETTING, "pk")
 
-        # avoid accessing session if it is empty
-        if getattr(request, 'session', None) and request.session.is_empty():
-            return message
+        self.request_id_header = getattr(settings, REQUEST_ID_HEADER_SETTING, None)
+        self.request_id_response_header = getattr(settings, REQUEST_ID_RESPONSE_HEADER_SETTING, False)
+        self.log_requests = getattr(settings, LOG_REQUESTS_SETTING, False)
 
-        user = getattr(request, 'user', None)
-        if not user:
-            return message
+        # fallback to NO_REQUEST_ID if settings asked to use the
+        # header request_id but none provided
+        self.default_request_id = getattr(settings, LOG_REQUESTS_NO_SETTING, DEFAULT_NO_REQUEST_ID)
 
-        user_id = getattr(user, user_attribute, None) or getattr(user, 'id', None)
-        message += ' user=' + str(user_id)
-        return message
+        # unless the setting GENERATE_REQUEST_ID_IF_NOT_IN_HEADER
+        # was set, in which case generate an id as normal if it wasn't
+        # passed in via the header
+        self.generate_request_if_not_in_header = getattr(settings, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING, False)
 
-    def process_response(self, request, response):
-        if getattr(settings, REQUEST_ID_RESPONSE_HEADER_SETTING, False) and getattr(request, 'id', None):
-            response[getattr(settings, REQUEST_ID_RESPONSE_HEADER_SETTING)] = request.id
+    def __call__(self, request):
+        local.request_id = request.id = request_id = self._get_request_id(request)
 
-        if not getattr(settings, LOG_REQUESTS_SETTING, False):
-            return response
+        response = self.get_response(request)
 
-        # Don't log favicon
-        if 'favicon' in request.path:
-            return response
+        if self.request_id_response_header:
+            response[self.request_id_response_header] = request_id
 
-        logger.info(self.get_log_message(request, response))
+        if self.log_requests and "favicon" not in request.path:
+            logger.info(self.get_log_message(request, response))
 
         try:
             del local.request_id
@@ -61,22 +50,31 @@ class RequestIDMiddleware(MiddlewareMixin):
 
         return response
 
+    def get_log_message(self, request, response):
+        message = f"method={request.method} path={request.path} status={response.status_code}"
+
+        if not self.log_user_attribute:
+            return message
+
+        # avoid accessing session if it is empty
+        if getattr(request, "session", None) and request.session.is_empty():
+            return message
+
+        if not (user := getattr(request, "user", None)):
+            return message
+
+        user_id = getattr(user, self.log_user_attribute, None) or getattr(user, "id", None)
+        message += f" user={user_id}"
+        return message
+
     def _get_request_id(self, request):
-        request_id_header = getattr(settings, REQUEST_ID_HEADER_SETTING, None)
-        generate_request_if_not_in_header = getattr(settings, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING, False)
+        if self.request_id_header:
+            default_request_id = self.default_request_id
 
-        if request_id_header:
-            # fallback to NO_REQUEST_ID if settings asked to use the
-            # header request_id but none provided
-            default_request_id = getattr(settings, LOG_REQUESTS_NO_SETTING, DEFAULT_NO_REQUEST_ID)
-
-            # unless the setting GENERATE_REQUEST_ID_IF_NOT_IN_HEADER
-            # was set, in which case generate an id as normal if it wasn't
-            # passed in via the header
-            if generate_request_if_not_in_header:
+            if self.generate_request_if_not_in_header:
                 default_request_id = self._generate_id()
 
-            return request.META.get(request_id_header, default_request_id)
+            return request.META.get(self.request_id_header, default_request_id)
 
         return self._generate_id()
 

--- a/log_request_id/tests.py
+++ b/log_request_id/tests.py
@@ -45,18 +45,15 @@ class RequestIDLoggingTestCase(TestCase):
 
     def test_id_generation(self):
         request = self.factory.get(self.url)
-        middleware = RequestIDMiddleware(get_response=lambda request: None)
-        middleware.process_request(request)
+        RequestIDMiddleware(get_response=self.call_view)(request)
         self.assertTrue(hasattr(request, 'id'))
-        self.call_view(request)
         self.assertTrue(request.id in self.handler.messages[0])
 
     def test_external_id_in_http_header(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER'):
             request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
+            RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertEqual(request.id, 'some_request_id')
             self.call_view(request)
             self.assertTrue('some_request_id' in self.handler.messages[0])
@@ -75,10 +72,8 @@ class RequestIDLoggingTestCase(TestCase):
     def test_external_id_missing_in_http_header_should_fallback_to_generated_id(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER', GENERATE_REQUEST_ID_IF_NOT_IN_HEADER=True):
             request = self.factory.get(self.url)
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
+            RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertTrue(hasattr(request, 'id'))
-            self.call_view(request)
             self.assertTrue(request.id in self.handler.messages[0])
 
     def test_log_requests(self):
@@ -89,10 +84,7 @@ class RequestIDLoggingTestCase(TestCase):
         with self.settings(LOG_REQUESTS=True):
             request = self.factory.get(self.url)
             request.user = DummyUser()
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
-            response = self.call_view(request)
-            middleware.process_response(request, response)
+            RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertEqual(len(self.handler.messages), 2)
             self.assertTrue('fake_pk' in self.handler.messages[1])
 
@@ -101,10 +93,7 @@ class RequestIDLoggingTestCase(TestCase):
             request = self.factory.get(self.url)
             request.user = DummyUser()
             request.session = SessionStore("session_key")
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
-            response = self.call_view(request)
-            middleware.process_response(request, response)
+            RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertEqual(len(self.handler.messages), 2)
             self.assertTrue('fake_username' in self.handler.messages[1])
 
@@ -112,10 +101,7 @@ class RequestIDLoggingTestCase(TestCase):
         with self.settings(LOG_REQUESTS=True, LOG_USER_ATTRIBUTE='username'):
             request = self.factory.get(self.url)
             request.session = SessionStore()
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
-            response = self.call_view(request)
-            middleware.process_response(request, response)
+            RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertEqual(len(self.handler.messages), 2)
             self.assertFalse('fake_username' in self.handler.messages[1])
             self.assertFalse(request.session.accessed)
@@ -125,10 +111,7 @@ class RequestIDLoggingTestCase(TestCase):
             request = self.factory.get(self.url)
             request.user = DummyUser()
             request.session = SessionStore("session_key")
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
-            response = self.call_view(request)
-            middleware.process_response(request, response)
+            RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertEqual(len(self.handler.messages), 2)
             self.assertFalse('fake_username' in self.handler.messages[1])
             self.assertFalse(request.session.accessed)
@@ -137,19 +120,14 @@ class RequestIDLoggingTestCase(TestCase):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER'):
             request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
-            response = self.call_view(request)
+            response = RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertFalse(response.has_header('REQUEST_ID'))
 
     def test_response_header_set(self):
         with self.settings(LOG_REQUEST_ID_HEADER='REQUEST_ID_HEADER', REQUEST_ID_RESPONSE_HEADER='REQUEST_ID'):
             request = self.factory.get(self.url)
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
-            middleware = RequestIDMiddleware(get_response=lambda request: None)
-            middleware.process_request(request)
-            response = self.call_view(request)
-            middleware.process_response(request, response)
+            response = RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertTrue(response.has_header('REQUEST_ID'))
 
 

--- a/log_request_id/tests.py
+++ b/log_request_id/tests.py
@@ -55,7 +55,6 @@ class RequestIDLoggingTestCase(TestCase):
             request.META['REQUEST_ID_HEADER'] = 'some_request_id'
             RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertEqual(request.id, 'some_request_id')
-            self.call_view(request)
             self.assertTrue('some_request_id' in self.handler.messages[0])
 
     def test_default_no_request_id_is_used(self):


### PR DESCRIPTION
This cleans up the request flow a little, and avoids the need to use `MiddlewareMixin`.

I also refactored the tests a little to use the entire middleware chain rather than calling the component pieces.