### PR TITLE
Clear the request ID on request_finished, rather than on the way "out" of the middleware

### DIFF
--- a/log_request_id/middleware.py
+++ b/log_request_id/middleware.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 
 from django.conf import settings
+from django.core.signals import request_finished
+from django.dispatch import receiver
 
 from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTING, DEFAULT_NO_REQUEST_ID, \
     REQUEST_ID_RESPONSE_HEADER_SETTING, GENERATE_REQUEST_ID_IF_NOT_IN_HEADER_SETTING, LOG_REQUESTS_NO_SETTING, \
@@ -9,6 +11,14 @@ from log_request_id import local, REQUEST_ID_HEADER_SETTING, LOG_REQUESTS_SETTIN
 
 
 logger = logging.getLogger(__name__)
+
+
+@receiver(request_finished)
+def _clear_request_id(**kwargs):
+    try:
+        del local.request_id
+    except AttributeError:
+        pass
 
 
 class RequestIDMiddleware:
@@ -44,11 +54,6 @@ class RequestIDMiddleware:
 
         if self.log_requests and "favicon" not in request.path:
             logger.info(self.get_log_message(request, response))
-
-        try:
-            del local.request_id
-        except AttributeError:
-            pass
 
         return response
 

--- a/log_request_id/tests.py
+++ b/log_request_id/tests.py
@@ -129,6 +129,13 @@ class RequestIDLoggingTestCase(TestCase):
             response = RequestIDMiddleware(get_response=self.call_view)(request)
             self.assertTrue(response.has_header('REQUEST_ID'))
 
+    def test_request_id_is_available_until_response_close(self):
+        request = self.factory.get(self.url)
+        response = RequestIDMiddleware(get_response=self.call_view)(request)
+        self.assertEqual(local.request_id, request.id)
+        response.close()
+        self.assertFalse(hasattr(local, 'request_id'))
+
 
 # asgiref is required from Django 3.0
 if async_to_sync:


### PR DESCRIPTION
#75 refactored `RequestIDMiddleware` and changed when `local.request_id` is cleared. Before that change, cleanup only happened on the `LOG_REQUESTS=True` path, so with the default `LOG_REQUESTS=False` the request ID remained available after the middleware returned. That behaviour was not documented and appears to have been an unintended side effect of where the cleanup lived, since request-ID lifetime should not depend on whether request logging is enabled. It wasn't _quite_ a bug, but it was certainly a bit odd. After #75 the `request_id` was cleared unconditionally.

However, issue #80 showed that some users relied on that "bug", as they are reading `log_request_id.local.request_id` from outer WSGI wrapper code after `django_application(...)` returned (in that case, to copy it into a uWSGI log variable).

This change moves cleanup to Django’s `request_finished` signal. That keeps the request ID available for the rest of the request/response lifecycle, including outer WSGI wrapper code that runs immediately after the Django application returns, while still ensuring the value is cleared at the end of the request instead of leaking indefinitely.